### PR TITLE
Added Student Assignment Class and Template URL

### DIFF
--- a/gradescope/__init__.py
+++ b/gradescope/__init__.py
@@ -1,5 +1,5 @@
 from .constants import Role
 from .gradescope import Gradescope
-from .dataclass import Course, Assignment, Member, Submission
+from .dataclass import Course, Assignment, StudentAssignment, Member, Submission
 from .errors import LoginError, NotLoggedInError, ResponseError
 from .utils import load_json, save_json, load_csv, save_csv, EnhancedJSONEncoder

--- a/gradescope/constants.py
+++ b/gradescope/constants.py
@@ -8,8 +8,8 @@ PAST_SUBMISSIONS = '.json?content=react&only_keys%5B%5D=past_submissions'
 
 
 ROLE_MAP = {
-    'student': 'Student Courses',
-    'instructor': 'Instructor Courses'
+    'student': ['Your Courses', 'Student Courses'],
+    'instructor': ['Instructor Courses']
 }
 
 

--- a/gradescope/constants.py
+++ b/gradescope/constants.py
@@ -14,5 +14,5 @@ ROLE_MAP = {
 
 
 class Role(Enum):
-    STUDENT     = 'student'
-    INSTRUCTOR  = 'instructor'
+    STUDENT = 'student'
+    INSTRUCTOR = 'instructor'

--- a/gradescope/dataclass.py
+++ b/gradescope/dataclass.py
@@ -62,6 +62,19 @@ class Assignment:
 
 
 @dataclass
+class StudentAssignment:
+    assignment_id: int
+    title: str
+    submission_url: str
+    template_url: str | None
+    submitted: bool
+    score: str | None
+    release_date: str
+    due_date: str
+    late_due_date: str | None
+
+
+@dataclass
 class Member:
     '''Represents a member (student or instructor) in Gradescope.'''
     member_id: int

--- a/gradescope/gradescope.py
+++ b/gradescope/gradescope.py
@@ -101,7 +101,7 @@ class Gradescope:
             log.warning('[Login] Login Failed.')
             self.logged_in = False
             return False
-        else:
+        else: 
             self.logged_in = False
             raise LoginError('Unknown return URL.')
 

--- a/gradescope/gradescope.py
+++ b/gradescope/gradescope.py
@@ -58,13 +58,15 @@ class Gradescope:
 
         Returns:
             bool: True if login is successful, False otherwise.
-        
+
         Raises:
             TypeError: If the username or password is None.
             LoginError: If the return URL after login is unknown.
         '''
-        if username is not None: self.username = username
-        if password is not None: self.password = password
+        if username is not None:
+            self.username = username
+        if password is not None:
+            self.password = password
         if self.username is None or self.password is None:
             raise TypeError('The username or password cannot be None.')
 
@@ -117,7 +119,8 @@ class Gradescope:
             NotLoggedInError: If not logged in.
             ResponseError: If the heading for the specified role is not found.
         '''
-        if not self.logged_in: raise NotLoggedInError
+        if not self.logged_in:
+            raise NotLoggedInError
 
         response = self.session.get(BASE_URL)
         self._response_check(response)
@@ -168,7 +171,8 @@ class Gradescope:
             NotLoggedInError: If not logged in.
             ResponseError: If the assignments table is empty or not found for the specified course.
         '''
-        if not self.logged_in: raise NotLoggedInError
+        if not self.logged_in:
+            raise NotLoggedInError
 
         response = self.session.get(course.get_url() + '/assignments')
         self._response_check(response)
@@ -215,7 +219,7 @@ class Gradescope:
         '''
         Retrieves the list of assignments visible to a student for the specified course.
 
-        This method parses the student-facing assignment table on Gradescope to extract information such as 
+        This method parses the student-facing assignment table on Gradescope to extract information such as
         assignment title, submission status, scores, due dates, and template download links.
 
         Args:
@@ -292,7 +296,8 @@ class Gradescope:
         Raises:
             NotLoggedInError: If not logged in.
         '''
-        if not self.logged_in: raise NotLoggedInError
+        if not self.logged_in:
+            raise NotLoggedInError
 
         response = self.session.get(course.get_url() + '/memberships')
         self._response_check(response)
@@ -339,7 +344,8 @@ class Gradescope:
         Raises:
             NotLoggedInError: If not logged in.
         '''
-        if not self.logged_in: raise NotLoggedInError
+        if not self.logged_in:
+            raise NotLoggedInError
 
         gradebook = self.get_gradebook(course, member)
         url = None
@@ -349,7 +355,7 @@ class Gradescope:
                 url = item_data.get('submission').get('url')
                 break
 
-        if url == None:
+        if url is None:
             return None
 
         response = self.session.get(urljoin(BASE_URL, url + PAST_SUBMISSIONS))
@@ -385,7 +391,8 @@ class Gradescope:
         Raises:
             NotLoggedInError: If the user is not logged in.
         '''
-        if not self.logged_in: raise NotLoggedInError
+        if not self.logged_in:
+            raise NotLoggedInError
 
         url = GRADEBOOK.format(
             course_id=course.course_id,
@@ -408,7 +415,8 @@ class Gradescope:
         Raises:
             NotLoggedInError: If the user is not logged in.
         '''
-        if not self.logged_in: raise NotLoggedInError
+        if not self.logged_in:
+            raise NotLoggedInError
 
         response = self.session.get(assignment.get_grades_url())
         self._response_check(response)
@@ -425,7 +433,8 @@ class Gradescope:
         Raises:
             NotLoggedInError: If the user is not logged in.
         '''
-        if not self.logged_in: raise NotLoggedInError
+        if not self.logged_in:
+            raise NotLoggedInError
 
         response = self.session.get(url)
         self._response_check(response)


### PR DESCRIPTION
The current implementation assumes you are only calling as an instructor, but non-instructor accounts may use this. Students only see "Your Courses" and not a separated "Student Courses" and "Instructor Courses.

- `Gradescope.get_assignments_as_student(course)` has been added and implemented to collect assignment data from the student's perspective—this has not been thoroughly tested and all of this is really becasue I went down a rabbit hole of trying to scrape the template pdf from an assignment if the instructor provided one (for CS 161/2 to be honest).
- The `StudentAssignment` dataclass has been added to represent minimal assignment data students can see—this is what the aforementioned method returns a list of.